### PR TITLE
III-3403 Add start and limit parameters to productions search endpoint

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -4283,7 +4283,7 @@
                 ]
             }
         },
-        "/productions": {
+        "/productions/": {
             "get": {
                 "summary": "Get a list of existing productions filtered by a search string",
                 "produces": [

--- a/swagger.json
+++ b/swagger.json
@@ -4296,6 +4296,20 @@
                         "description": "The name or part of the name of the production(s) to search (case-insensitive).",
                         "required": true,
                         "type": "string"
+                    },
+                    {
+                        "name": "start",
+                        "in": "query",
+                        "description": "The number of productions to skip from the start of the result set. When omitted it starts from the first position (0).",
+                        "required": false,
+                        "type": "integer"
+                    },
+                    {
+                        "name": "limit",
+                        "in": "query",
+                        "description": "The limit of productions included in the result set. When omitted it defaults to 30 items.",
+                        "required": false,
+                        "type": "integer"
                     }
                 ],
                 "responses": {

--- a/swagger.json
+++ b/swagger.json
@@ -4318,7 +4318,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/Production"
+                                "$ref": "#/definitions/ProductionSearchResult"
                             }
                         }
                     }
@@ -6484,6 +6484,31 @@
                     "example": "everyone"
                 }
             }
+        },
+        "ProductionSearchResult": {
+            "properties": {
+                "itemsPerPage": {
+                    "type": "integer",
+                    "format": "int32",
+                    "example": 30
+                },
+                "totalItems": {
+                    "type": "integer",
+                    "format": "int32",
+                    "example": 3562
+                },
+                "member": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/Production"
+                    }
+                }
+            },
+            "required": [
+                "itemsPerPage",
+                "totalItems",
+                "member"
+            ]
         },
         "Production": {
             "properties": {


### PR DESCRIPTION
### Added

- Added `start` parameter to productions search endpoint
- Added `limit` parameter to productions search endpoint

### Changed

- Changed production search response to paged collection

---
Ticket: https://jira.uitdatabank.be/browse/III-3403

---
Notes: See https://jira.uitdatabank.be/secure/attachment/26750/26750_Producties_overview.png for why we need this